### PR TITLE
Add remix-params-helper to packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A curated list of awesome [Remix 💿](https://remix.run) packages and resources
 - [remix-utils](https://github.com/sergiodxa/remix-utils) - A set of utility functions and types to use with Remix.run
 - [remix-i18next](https://github.com/sergiodxa/remix-i18next) - The easiest way to translate your Remix apps
 - [remix-seo](https://github.com/chaance/remix-seo) - A package for easily managing SEO meta and link tags in Remix.
+- [remix-params-helper](https://github.com/kiliman/remix-params-helper) - Helpers that make it simple to use Zod with URLSearchParams, FormData, and Remix params object
 
 ## Templates
 


### PR DESCRIPTION
This package makes it simple to use Zod with standard URLSearchParams and FormData which are typically used in Remix apps.